### PR TITLE
Fixed race condition when send the request and subscribe to error/response events

### DIFF
--- a/src/http2.ts
+++ b/src/http2.ts
@@ -52,9 +52,6 @@ export async function _fetch(url: URL, options?: _FetchOptions): Promise<_FetchR
     req.write(options.body)
   }
 
-  // Send the request
-  req.end()
-
   // Fetch the headers
   const { headers, status } = await _responseHeaders(req, options)
 
@@ -137,6 +134,9 @@ function _responseHeaders(
         status: Number(headers[constants.HTTP2_HEADER_STATUS])
       })
     )
+
+    // Send the request
+    req.end()
   })
 }
 


### PR DESCRIPTION
Hello,

I was checking the code before integrating it, and I noticed a _possible_ race condition.

You're calling `req.end()` before subscribing to the request `error` / `response` events. So, in the case that the server responds before the listeners, the code will be locked forever.

I tested it by wrapping the content of `_responseHeaders` into a `setTimeout` to reproduce the case.

If you simply move `req.end()` after the `req.on(...` events are created, you could avoid this possible race condition and it is a good practice to avoid potential other future issues.