### PR TITLE
Fixed 'error' is undefined when the request is timed out

### DIFF
--- a/src/http2.ts
+++ b/src/http2.ts
@@ -126,7 +126,10 @@ function _sendRequest(
 
     // Apply optional timeout
     if (options && typeof options.timeout === 'number') {
-      req.setTimeout(options.timeout, reject)
+      req.setTimeout(options.timeout, () => {
+        req.close(constants.NGHTTP2_CANCEL)
+        reject(new Error('Request Timeout'))
+      })
     }
 
     // Add error handler

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -9,4 +9,17 @@ describe('fetch', () => {
     assert.exists(json.slideshow)
     assert.equal(json.slideshow.title, 'Sample Slide Show')
   })
+
+  it('should timeout', async () => {
+    let error
+    try {
+      await fetch('https://httpbin.org/json', {
+        timeout: 1
+      })
+    } catch (_error) {
+      error = _error
+    }
+    assert.exists(error)
+    assert.equal(error.message, 'Request Timeout')
+  })
 })


### PR DESCRIPTION
When your request is timed out, the variable `error` in your try catch is undefined.

**Reproducible Example 1:**
```
try {
  await fetch('https://httpbin.org/json', {
    timeout: 1
  })
} catch (error) {
  console.log(error) // error: undefined
}
```

**Reproducible Example 2:**
Run the test that I created in this PR without the fix applied

The function `req.setTimeout` does not return any parameter in their callback, also you need to close the request with status `NGHTTP2_CANCEL`

Source: https://nodejs.org/api/http2.html#http2streamsettimeoutmsecs-callback